### PR TITLE
Adicionando content-type no header

### DIFF
--- a/easymock.js
+++ b/easymock.js
@@ -16,7 +16,8 @@ var allowCrossDomain = function (req, res, next) {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
     res.header('Access-Control-Allow-Headers', 'Content-Type');
-
+    res.header('Content-Type', 'Application/JSON');
+    
     next();
 }
 


### PR DESCRIPTION
Adicionando parâmetro Content-Type do header para permitir que o objeto de retorno seja lido no formato adequado por acessos remotos ao servidor